### PR TITLE
Update Docker image ref.

### DIFF
--- a/_build/preliminaries.html
+++ b/_build/preliminaries.html
@@ -62,7 +62,7 @@ pip install --upgrade madminer
 -->
 
 <p>Get the MadMiner repository with tutorial notebooks</p>
-<div class="highlight"><pre><span></span>git clone https://github.com/diana-hep/madminer.git
+<div class="highlight"><pre><span></span>git clone --depth=1 https://github.com/diana-hep/madminer.git
 </pre></div>
 <p>Now move to the directory with the example tutorial</p>
 <div class="highlight"><pre><span></span><span class="nb">cd</span> madminer/examples/tutorial_particle_physics

--- a/_build/preliminaries.html
+++ b/_build/preliminaries.html
@@ -44,7 +44,7 @@ Irina Espejo has built Docker containers with everything installed already and p
 <p>(You can put it somewhere else if you want, but I'll assume it's there)</p>
 <h2 id="Get-tutorial-&amp;-start-Jupyter-in-container">Get tutorial &amp; start Jupyter in container<a class="anchor-link" href="#Get-tutorial-&amp;-start-Jupyter-in-container"> </a></h2><p>Enter an interactive session in the MadMiner docker container.
 The first time you execute this it will need to pull the container, which will take about a minute.</p>
-<div class="highlight"><pre><span></span>docker run -p <span class="m">8888</span>:8888 -v ~/madminer_shared:/home/shared -it madminertool/docker-madminer-all /bin/bash
+<div class="highlight"><pre><span></span>docker run -p <span class="m">8888</span>:8888 -v ~/madminer_shared:/home/shared -it madminertool/madminer-jupyter-env /bin/bash
 </pre></div>
 <p>(If you are using Docker Toolbox on windows, see section below.)</p>
 <p>Now you have a prompt inside the container. See what's there and then go into the <code>shared</code> directory</p>
@@ -81,13 +81,13 @@ pip install --upgrade madminer
 <p>Now you should be all set and see something like this.</p>
 <p><img src="/madminer-tutorial/images/notebook.png" alt=""></p>
 <h2 id="Updating-the-docker-image">Updating the docker image<a class="anchor-link" href="#Updating-the-docker-image"> </a></h2><p>While developig and testing this tutorial we may occasionally update the docker image. If you completed the preliminaries some time ago, you might want to update with:</p>
-<div class="highlight"><pre><span></span>docker pull madminertool/docker-madminer-all
+<div class="highlight"><pre><span></span>docker pull madminertool/madminer-jupyter-env
 </pre></div>
 <p>This will replace all the contents of the docker image, but not the files in the shared directory. YOu will still want to re-do the 
 steps described above in <strong>Get tutorial &amp; start Jupyter in container</strong>.</p>
 <h2 id="Special-instructions-for-Docker-Toolbox-Windows">Special instructions for Docker Toolbox Windows<a class="anchor-link" href="#Special-instructions-for-Docker-Toolbox-Windows"> </a></h2><p>Thanks to Ioannis Karkanias for these notes on Docker Toolbox</p>
 <p>1) The 
-<code>docker run -p 8888:8888 -v ~/madminer_shared:/home/shared -it madminertool/docker-madminer-all /bin/bash</code> 
+<code>docker run -p 8888:8888 -v ~/madminer_shared:/home/shared -it madminertool/madminer-jupyter-env /bin/bash</code>
 command's -v argument needs to be something like this</p>
 <div class="highlight"><pre><span></span>-v /c/Users/kark/madminer_shared:/home/shared
 </pre></div>

--- a/_build/set_mg_dir.html
+++ b/_build/set_mg_dir.html
@@ -25,7 +25,7 @@ comment: "***PROGRAMMATICALLY GENERATED, DO NOT EDIT. SEE ORIGINAL FILES IN /con
 <h1 id="Set-the-MadGraph-Directory">Set the MadGraph Directory<a class="anchor-link" href="#Set-the-MadGraph-Directory"> </a></h1><p>In part <code>2a_parton_level</code> and/or <code>2b_delphes_level_analysis</code> in Cell 3, the location of MadGraph is set.
 In this webpage it is listed as</p>
 
-<pre><code>mg_dir = '/home/software/MG5_aMC_v2_6_7'</code></pre>
+<pre><code>mg_dir = '/madminer/software/MG5_aMC_v2_6_7'</code></pre>
 <p>If you install everything yourself, then you would also need to change this to point to madgraph on your system.</p>
 
 </div>

--- a/_build/tutorial_particle_physics/2a_parton_level_analysis.html
+++ b/_build/tutorial_particle_physics/2a_parton_level_analysis.html
@@ -138,7 +138,7 @@ comment: "***PROGRAMMATICALLY GENERATED, DO NOT EDIT. SEE ORIGINAL FILES IN /con
 
 <div class="inner_cell">
     <div class="input_area">
-<div class=" highlight hl-ipython2"><pre><span></span><span class="n">mg_dir</span> <span class="o">=</span> <span class="s1">&#39;/home/software/MG5_aMC_v2_6_7&#39;</span>
+<div class=" highlight hl-ipython2"><pre><span></span><span class="n">mg_dir</span> <span class="o">=</span> <span class="s1">&#39;/madminer/software/MG5_aMC_v2_6_7&#39;</span>
 </pre></div>
 
     </div>

--- a/_build/tutorial_particle_physics/2b_delphes_level_analysis.html
+++ b/_build/tutorial_particle_physics/2b_delphes_level_analysis.html
@@ -138,7 +138,7 @@ comment: "***PROGRAMMATICALLY GENERATED, DO NOT EDIT. SEE ORIGINAL FILES IN /con
 
 <div class="inner_cell">
     <div class="input_area">
-<div class=" highlight hl-ipython2"><pre><span></span><span class="n">mg_dir</span> <span class="o">=</span> <span class="s1">&#39;/madminer/software/MG5_aMC_v2_6_2/&#39;</span>
+<div class=" highlight hl-ipython2"><pre><span></span><span class="n">mg_dir</span> <span class="o">=</span> <span class="s1">&#39;/madminer/software/MG5_amC_v2_6_7/&#39;</span>
 </pre></div>
 
     </div>

--- a/_build/tutorial_particle_physics/2b_delphes_level_analysis.html
+++ b/_build/tutorial_particle_physics/2b_delphes_level_analysis.html
@@ -138,7 +138,7 @@ comment: "***PROGRAMMATICALLY GENERATED, DO NOT EDIT. SEE ORIGINAL FILES IN /con
 
 <div class="inner_cell">
     <div class="input_area">
-<div class=" highlight hl-ipython2"><pre><span></span><span class="n">mg_dir</span> <span class="o">=</span> <span class="s1">&#39;/home/software/MG5_aMC_v2_6_2/&#39;</span>
+<div class=" highlight hl-ipython2"><pre><span></span><span class="n">mg_dir</span> <span class="o">=</span> <span class="s1">&#39;/madminer/software/MG5_aMC_v2_6_2/&#39;</span>
 </pre></div>
 
     </div>

--- a/_build/tutorial_particle_physics/4c_information_geometry.html
+++ b/_build/tutorial_particle_physics/4c_information_geometry.html
@@ -52,7 +52,7 @@ comment: "***PROGRAMMATICALLY GENERATED, DO NOT EDIT. SEE ORIGINAL FILES IN /con
     <div class="input_area">
 <div class=" highlight hl-ipython3"><pre><span></span><span class="kn">import</span> <span class="nn">sys</span>
 <span class="kn">import</span> <span class="nn">os</span>
-<span class="n">madminer_src_path</span> <span class="o">=</span> <span class="s2">&quot;/home/software/MG5_aMC_v2_6_7/&quot;</span>
+<span class="n">madminer_src_path</span> <span class="o">=</span> <span class="s2">&quot;/madminer/software/MG5_aMC_v2_6_7/&quot;</span>
 <span class="n">sys</span><span class="o">.</span><span class="n">path</span><span class="o">.</span><span class="n">append</span><span class="p">(</span><span class="n">madminer_src_path</span><span class="p">)</span>
 
 <span class="kn">from</span> <span class="nn">__future__</span> <span class="k">import</span> <span class="n">absolute_import</span><span class="p">,</span> <span class="n">division</span><span class="p">,</span> <span class="n">print_function</span><span class="p">,</span> <span class="n">unicode_literals</span>

--- a/_build/tutorial_particle_physics/A1_systematic_uncertainties.html
+++ b/_build/tutorial_particle_physics/A1_systematic_uncertainties.html
@@ -114,7 +114,7 @@ comment: "***PROGRAMMATICALLY GENERATED, DO NOT EDIT. SEE ORIGINAL FILES IN /con
 
 <div class="inner_cell">
     <div class="input_area">
-<div class=" highlight hl-ipython2"><pre><span></span><span class="n">mg_dir</span> <span class="o">=</span> <span class="s2">&quot;/madminer/software/MG5_aMC_v2_6_2/&quot;</span>
+<div class=" highlight hl-ipython2"><pre><span></span><span class="n">mg_dir</span> <span class="o">=</span> <span class="s2">&quot;/madminer/software/MG5_amC_v2_6_7/&quot;</span>
 </pre></div>
 
     </div>

--- a/_build/tutorial_particle_physics/A1_systematic_uncertainties.html
+++ b/_build/tutorial_particle_physics/A1_systematic_uncertainties.html
@@ -114,7 +114,7 @@ comment: "***PROGRAMMATICALLY GENERATED, DO NOT EDIT. SEE ORIGINAL FILES IN /con
 
 <div class="inner_cell">
     <div class="input_area">
-<div class=" highlight hl-ipython2"><pre><span></span><span class="n">mg_dir</span> <span class="o">=</span> <span class="s2">&quot;/home/software/MG5_aMC_v2_6_2/&quot;</span>
+<div class=" highlight hl-ipython2"><pre><span></span><span class="n">mg_dir</span> <span class="o">=</span> <span class="s2">&quot;/madminer/software/MG5_aMC_v2_6_2/&quot;</span>
 </pre></div>
 
     </div>

--- a/_site/content/preliminaries.md
+++ b/_site/content/preliminaries.md
@@ -43,7 +43,7 @@ mkdir ~/madminer_shared
 Enter an interactive session in the MadMiner docker container.
 The first time you execute this it will need to pull the container, which will take about a minute.
 ```bash
-docker run -p 8888:8888 -v ~/madminer_shared:/home/shared -it madminertool/docker-madminer-all /bin/bash
+docker run -p 8888:8888 -v ~/madminer_shared:/home/shared -it madminertool/madminer-jupyter-env /bin/bash
 ```
 (If you are using Docker Toolbox on windows, see section below.)
 
@@ -100,7 +100,7 @@ Now you should be all set and see something like this.
 
 While developig and testing this tutorial we may occasionally update the docker image. If you completed the preliminaries some time ago, you might want to update with:
 ```shell
-docker pull madminertool/docker-madminer-all
+docker pull madminertool/madminer-jupyter-env
 ```
 This will replace all the contents of the docker image, but not the files in the shared directory. YOu will still want to re-do the 
 steps described above in **Get tutorial & start Jupyter in container**.
@@ -110,7 +110,7 @@ steps described above in **Get tutorial & start Jupyter in container**.
 Thanks to Ioannis Karkanias for these notes on Docker Toolbox
 
 1) The 
-```docker run -p 8888:8888 -v ~/madminer_shared:/home/shared -it madminertool/docker-madminer-all /bin/bash``` 
+```docker run -p 8888:8888 -v ~/madminer_shared:/home/shared -it madminertool/madminer-jupyter-env /bin/bash``` 
 command's -v argument needs to be something like this
 
 ```shell

--- a/_site/content/preliminaries.md
+++ b/_site/content/preliminaries.md
@@ -52,7 +52,7 @@ Now you have a prompt inside the container. See what's there and then go into th
 ```bash
 pwd
 ls
-cd shared
+cd /home/shared
 echo 'hello world' >> test.txt
 ```
 

--- a/_site/content/preliminaries.md
+++ b/_site/content/preliminaries.md
@@ -67,7 +67,7 @@ pip install --upgrade madminer
 
 Get the MadMiner repository with tutorial notebooks
 ```bash
-git clone https://github.com/diana-hep/madminer.git
+git clone --depth=1 https://github.com/diana-hep/madminer.git
 ```
 
 Now move to the directory with the example tutorial

--- a/_site/content/set_mg_dir.md
+++ b/_site/content/set_mg_dir.md
@@ -3,7 +3,7 @@
 In part `2a_parton_level` and/or `2b_delphes_level_analysis` in Cell 3, the location of MadGraph is set.
 In this webpage it is listed as 
 ```
-mg_dir = '/home/software/MG5_aMC_v2_6_7'
+mg_dir = '/madminer/software/MG5_aMC_v2_6_7'
 ```
 
 If you install everything yourself, then you would also need to change this to point to madgraph on your system.

--- a/_site/content/tutorial_particle_physics/2a_parton_level_analysis.ipynb
+++ b/_site/content/tutorial_particle_physics/2a_parton_level_analysis.ipynb
@@ -84,7 +84,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mg_dir = '/home/software/MG5_aMC_v2_6_7'"
+    "mg_dir = '/madminer/software/MG5_aMC_v2_6_7'"
    ]
   },
   {

--- a/_site/content/tutorial_particle_physics/2b_delphes_level_analysis.ipynb
+++ b/_site/content/tutorial_particle_physics/2b_delphes_level_analysis.ipynb
@@ -84,7 +84,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mg_dir = '/home/software/MG5_aMC_v2_6_2/'"
+    "mg_dir = '/madminer/software/MG5_aMC_v2_6_2/'"
    ]
   },
   {

--- a/_site/content/tutorial_particle_physics/2b_delphes_level_analysis.ipynb
+++ b/_site/content/tutorial_particle_physics/2b_delphes_level_analysis.ipynb
@@ -84,7 +84,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mg_dir = '/madminer/software/MG5_aMC_v2_6_2/'"
+    "mg_dir = '/madminer/software/MG5_amC_v2_6_7/'"
    ]
   },
   {

--- a/_site/content/tutorial_particle_physics/4c_information_geometry.ipynb
+++ b/_site/content/tutorial_particle_physics/4c_information_geometry.ipynb
@@ -26,7 +26,7 @@
    "source": [
     "import sys\n",
     "import os\n",
-    "madminer_src_path = \"/home/software/MG5_aMC_v2_6_7/\"\n",
+    "madminer_src_path = \"/madminer/software/MG5_aMC_v2_6_7/\"\n",
     "sys.path.append(madminer_src_path)\n",
     "\n",
     "from __future__ import absolute_import, division, print_function, unicode_literals\n",

--- a/_site/content/tutorial_particle_physics/A1_systematic_uncertainties.ipynb
+++ b/_site/content/tutorial_particle_physics/A1_systematic_uncertainties.ipynb
@@ -68,7 +68,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mg_dir = \"/madminer/software/MG5_aMC_v2_6_2/\""
+    "mg_dir = \"/madminer/software/MG5_amC_v2_6_7/\""
    ]
   },
   {

--- a/_site/content/tutorial_particle_physics/A1_systematic_uncertainties.ipynb
+++ b/_site/content/tutorial_particle_physics/A1_systematic_uncertainties.ipynb
@@ -68,7 +68,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mg_dir = \"/home/software/MG5_aMC_v2_6_2/\""
+    "mg_dir = \"/madminer/software/MG5_aMC_v2_6_2/\""
    ]
   },
   {

--- a/_site/preliminaries.html
+++ b/_site/preliminaries.html
@@ -1133,7 +1133,7 @@ pip install --upgrade madminer
 -->
 
 <p>Get the MadMiner repository with tutorial notebooks</p>
-<div class="highlight"><pre><span></span>git clone https://github.com/diana-hep/madminer.git
+<div class="highlight"><pre><span></span>git clone --depth=1 https://github.com/diana-hep/madminer.git
 </pre></div>
 <p>Now move to the directory with the example tutorial</p>
 <div class="highlight"><pre><span></span><span class="nb">cd</span> madminer/examples/tutorial_particle_physics

--- a/_site/preliminaries.html
+++ b/_site/preliminaries.html
@@ -1115,7 +1115,7 @@ Irina Espejo has built Docker containers with everything installed already and p
 <p>(You can put it somewhere else if you want, but I'll assume it's there)</p>
 <h2 id="Get-tutorial-&amp;-start-Jupyter-in-container">Get tutorial &amp; start Jupyter in container<a class="anchor-link" href="#Get-tutorial-&amp;-start-Jupyter-in-container"> </a></h2><p>Enter an interactive session in the MadMiner docker container.
 The first time you execute this it will need to pull the container, which will take about a minute.</p>
-<div class="highlight"><pre><span></span>docker run -p <span class="m">8888</span>:8888 -v ~/madminer_shared:/home/shared -it madminertool/docker-madminer-all /bin/bash
+<div class="highlight"><pre><span></span>docker run -p <span class="m">8888</span>:8888 -v ~/madminer_shared:/home/shared -it madminertool/madminer-jupyter-env /bin/bash
 </pre></div>
 <p>(If you are using Docker Toolbox on windows, see section below.)</p>
 <p>Now you have a prompt inside the container. See what's there and then go into the <code>shared</code> directory</p>
@@ -1151,15 +1151,15 @@ pip install --upgrade madminer
 <p>Now you should be able to connect to the Jupyter notebook server inside the container using your normal browser. Click this link (open in a new tab): <a href="localhost:8888">localhost:8888</a>. (If you are using Docker Toolbox on windows, see section below.) You should see a Jupyter terminal and it will ask for a login token. Paste the token (in this example, <code>123copywhatyouseeherexyz</code>) and login.</p>
 <p>Now you should be all set and see something like this.</p>
 <p><img src="/madminer-tutorial/images/notebook.png" alt=""></p>
-<h2 id="Updating-the-docker-image">Updating the docker image<a class="anchor-link" href="#Updating-the-docker-image"> </a></h2><p>While developig and testing this tutorial we may occasionally update the docker image. If you completed the preliminaries some time ago, you might want to update with:</p>
-<div class="highlight"><pre><span></span>docker pull madminertool/docker-madminer-all
+<h2 id="Updating-the-docker-image">Updating the docker image<a class="anchor-link" href="#Updating-the-docker-image"> </a></h2><p>While developing and testing this tutorial we may occasionally update the docker image. If you completed the preliminaries some time ago, you might want to update with:</p>
+<div class="highlight"><pre><span></span>docker pull madminertool/madminer-jupyter-env
 </pre></div>
 <p>This will replace all the contents of the docker image, but not the files in the shared directory. YOu will still want to re-do the 
-steps described above in <strong>Get tutorial &amp; start Jupyter in container</strong>.</p>
+steps described above in <strong>Get tutorial &amp; start Jupyter in a container</strong>.</p>
 <h2 id="Special-instructions-for-Docker-Toolbox-Windows">Special instructions for Docker Toolbox Windows<a class="anchor-link" href="#Special-instructions-for-Docker-Toolbox-Windows"> </a></h2><p>Thanks to Ioannis Karkanias for these notes on Docker Toolbox</p>
 <p>1) The 
-<code>docker run -p 8888:8888 -v ~/madminer_shared:/home/shared -it madminertool/docker-madminer-all /bin/bash</code> 
-command's -v argument needs to be something like this</p>
+<code>docker run -p 8888:8888 -v ~/madminer_shared:/home/shared -it madminertool/madminer-jupyter-env /bin/bash</code>
+command's -v argument needs to be something like this.</p>
 <div class="highlight"><pre><span></span>-v /c/Users/kark/madminer_shared:/home/shared
 </pre></div>
 <p>(replace <code>kark</code> is your username). The shared folder needs to be in the <code>Users/</code> directory, as the Docker Toolbox uses VirtualBox and the shared folder specified for the machine that is created in VirtualBox only has <code>C:/Users/</code> as a shared folder. There are instructions <a href="https://docs.docker.com/toolbox/toolbox_install_windows/#optional-add-shared-directories">here</a></p>

--- a/_site/set_mg_dir.html
+++ b/_site/set_mg_dir.html
@@ -1094,7 +1094,7 @@ initFunction(initPrint)
 <h1 id="Set-the-MadGraph-Directory">Set the MadGraph Directory<a class="anchor-link" href="#Set-the-MadGraph-Directory"> </a></h1><p>In part <code>2a_parton_level</code> and/or <code>2b_delphes_level_analysis</code> in Cell 3, the location of MadGraph is set.
 In this webpage it is listed as</p>
 
-<pre><code>mg_dir = '/home/software/MG5_aMC_v2_6_7'</code></pre>
+<pre><code>mg_dir = '/madminer/software/MG5_aMC_v2_6_7'</code></pre>
 <p>If you install everything yourself, then you would also need to change this to point to madgraph on your system.</p>
 
 </div>

--- a/_site/tutorial_particle_physics/2a_parton_level_analysis.html
+++ b/_site/tutorial_particle_physics/2a_parton_level_analysis.html
@@ -1219,7 +1219,7 @@ initFunction(initPrint)
 
 <div class="inner_cell">
     <div class="input_area">
-<div class=" highlight hl-ipython2"><pre><span></span><span class="n">mg_dir</span> <span class="o">=</span> <span class="s1">&#39;/home/software/MG5_aMC_v2_6_7&#39;</span>
+<div class=" highlight hl-ipython2"><pre><span></span><span class="n">mg_dir</span> <span class="o">=</span> <span class="s1">&#39;/madminer/software/MG5_aMC_v2_6_7&#39;</span>
 </pre></div>
 
     </div>

--- a/_site/tutorial_particle_physics/2b_delphes_level_analysis.html
+++ b/_site/tutorial_particle_physics/2b_delphes_level_analysis.html
@@ -1219,7 +1219,7 @@ initFunction(initPrint)
 
 <div class="inner_cell">
     <div class="input_area">
-<div class=" highlight hl-ipython2"><pre><span></span><span class="n">mg_dir</span> <span class="o">=</span> <span class="s1">&#39;/home/software/MG5_aMC_v2_6_2/&#39;</span>
+<div class=" highlight hl-ipython2"><pre><span></span><span class="n">mg_dir</span> <span class="o">=</span> <span class="s1">&#39;/madminer/software/MG5_aMC_v2_6_2/&#39;</span>
 </pre></div>
 
     </div>

--- a/_site/tutorial_particle_physics/2b_delphes_level_analysis.html
+++ b/_site/tutorial_particle_physics/2b_delphes_level_analysis.html
@@ -1219,7 +1219,7 @@ initFunction(initPrint)
 
 <div class="inner_cell">
     <div class="input_area">
-<div class=" highlight hl-ipython2"><pre><span></span><span class="n">mg_dir</span> <span class="o">=</span> <span class="s1">&#39;/madminer/software/MG5_aMC_v2_6_2/&#39;</span>
+<div class=" highlight hl-ipython2"><pre><span></span><span class="n">mg_dir</span> <span class="o">=</span> <span class="s1">&#39;/madminer/software/MG5_amC_v2_6_7/&#39;</span>
 </pre></div>
 
     </div>

--- a/_site/tutorial_particle_physics/4c_information_geometry.html
+++ b/_site/tutorial_particle_physics/4c_information_geometry.html
@@ -1133,7 +1133,7 @@ initFunction(initPrint)
     <div class="input_area">
 <div class=" highlight hl-ipython3"><pre><span></span><span class="kn">import</span> <span class="nn">sys</span>
 <span class="kn">import</span> <span class="nn">os</span>
-<span class="n">madminer_src_path</span> <span class="o">=</span> <span class="s2">&quot;/home/software/MG5_aMC_v2_6_7/&quot;</span>
+<span class="n">madminer_src_path</span> <span class="o">=</span> <span class="s2">&quot;/madminer/software/MG5_aMC_v2_6_7/&quot;</span>
 <span class="n">sys</span><span class="o">.</span><span class="n">path</span><span class="o">.</span><span class="n">append</span><span class="p">(</span><span class="n">madminer_src_path</span><span class="p">)</span>
 
 <span class="kn">from</span> <span class="nn">__future__</span> <span class="k">import</span> <span class="n">absolute_import</span><span class="p">,</span> <span class="n">division</span><span class="p">,</span> <span class="n">print_function</span><span class="p">,</span> <span class="n">unicode_literals</span>

--- a/_site/tutorial_particle_physics/A1_systematic_uncertainties.html
+++ b/_site/tutorial_particle_physics/A1_systematic_uncertainties.html
@@ -1195,7 +1195,7 @@ initFunction(initPrint)
 
 <div class="inner_cell">
     <div class="input_area">
-<div class=" highlight hl-ipython2"><pre><span></span><span class="n">mg_dir</span> <span class="o">=</span> <span class="s2">&quot;/madminer/software/MG5_aMC_v2_6_2/&quot;</span>
+<div class=" highlight hl-ipython2"><pre><span></span><span class="n">mg_dir</span> <span class="o">=</span> <span class="s2">&quot;/madminer/software/MG5_amC_v2_6_7/&quot;</span>
 </pre></div>
 
     </div>

--- a/_site/tutorial_particle_physics/A1_systematic_uncertainties.html
+++ b/_site/tutorial_particle_physics/A1_systematic_uncertainties.html
@@ -1195,7 +1195,7 @@ initFunction(initPrint)
 
 <div class="inner_cell">
     <div class="input_area">
-<div class=" highlight hl-ipython2"><pre><span></span><span class="n">mg_dir</span> <span class="o">=</span> <span class="s2">&quot;/home/software/MG5_aMC_v2_6_2/&quot;</span>
+<div class=" highlight hl-ipython2"><pre><span></span><span class="n">mg_dir</span> <span class="o">=</span> <span class="s2">&quot;/madminer/software/MG5_aMC_v2_6_2/&quot;</span>
 </pre></div>
 
     </div>

--- a/content/preliminaries.md
+++ b/content/preliminaries.md
@@ -43,7 +43,7 @@ mkdir ~/madminer_shared
 Enter an interactive session in the MadMiner docker container.
 The first time you execute this it will need to pull the container, which will take about a minute.
 ```bash
-docker run -p 8888:8888 -v ~/madminer_shared:/home/shared -it madminertool/docker-madminer-all /bin/bash
+docker run -p 8888:8888 -v ~/madminer_shared:/home/shared -it madminertool/madminer-jupyter-env /bin/bash
 ```
 (If you are using Docker Toolbox on windows, see section below.)
 
@@ -98,20 +98,20 @@ Now you should be all set and see something like this.
 
 ## Updating the docker image
 
-While developig and testing this tutorial we may occasionally update the docker image. If you completed the preliminaries some time ago, you might want to update with:
+While developing and testing this tutorial we may occasionally update the docker image. If you completed the preliminaries some time ago, you might want to update with:
 ```shell
-docker pull madminertool/docker-madminer-all
+docker pull madminertool/madminer-jupyter-env
 ```
 This will replace all the contents of the docker image, but not the files in the shared directory. YOu will still want to re-do the 
-steps described above in **Get tutorial & start Jupyter in container**.
+steps described above in **Get tutorial & start Jupyter in a container**.
 
 ## Special instructions for Docker Toolbox Windows 
 
 Thanks to Ioannis Karkanias for these notes on Docker Toolbox
 
 1) The 
-```docker run -p 8888:8888 -v ~/madminer_shared:/home/shared -it madminertool/docker-madminer-all /bin/bash``` 
-command's -v argument needs to be something like this
+```docker run -p 8888:8888 -v ~/madminer_shared:/home/shared -it madminertool/madminer-jupyter-env /bin/bash``` 
+command's -v argument needs to be something like this.
 
 ```shell
 -v /c/Users/kark/madminer_shared:/home/shared

--- a/content/preliminaries.md
+++ b/content/preliminaries.md
@@ -52,7 +52,7 @@ Now you have a prompt inside the container. See what's there and then go into th
 ```bash
 pwd
 ls
-cd shared
+cd /home/shared
 echo 'hello world' >> test.txt
 ```
 

--- a/content/preliminaries.md
+++ b/content/preliminaries.md
@@ -67,7 +67,7 @@ pip install --upgrade madminer
 
 Get the MadMiner repository with tutorial notebooks
 ```bash
-git clone https://github.com/diana-hep/madminer.git
+git clone --depth=1 https://github.com/diana-hep/madminer.git
 ```
 
 Now move to the directory with the example tutorial

--- a/content/set_mg_dir.md
+++ b/content/set_mg_dir.md
@@ -3,7 +3,7 @@
 In part `2a_parton_level` and/or `2b_delphes_level_analysis` in Cell 3, the location of MadGraph is set.
 In this webpage it is listed as 
 ```
-mg_dir = '/home/software/MG5_aMC_v2_6_7'
+mg_dir = '/madminer/software/MG5_aMC_v2_6_7'
 ```
 
 If you install everything yourself, then you would also need to change this to point to madgraph on your system.

--- a/content/tutorial_particle_physics/2a_parton_level_analysis.ipynb
+++ b/content/tutorial_particle_physics/2a_parton_level_analysis.ipynb
@@ -84,7 +84,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mg_dir = '/home/software/MG5_aMC_v2_6_7'"
+    "mg_dir = '/madminer/software/MG5_aMC_v2_6_7'"
    ]
   },
   {

--- a/content/tutorial_particle_physics/2b_delphes_level_analysis.ipynb
+++ b/content/tutorial_particle_physics/2b_delphes_level_analysis.ipynb
@@ -84,7 +84,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mg_dir = '/home/software/MG5_aMC_v2_6_2/'"
+    "mg_dir = '/madminer/software/MG5_aMC_v2_6_2/'"
    ]
   },
   {

--- a/content/tutorial_particle_physics/2b_delphes_level_analysis.ipynb
+++ b/content/tutorial_particle_physics/2b_delphes_level_analysis.ipynb
@@ -84,7 +84,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mg_dir = '/madminer/software/MG5_aMC_v2_6_2/'"
+    "mg_dir = '/madminer/software/MG5_amC_v2_6_7/'"
    ]
   },
   {

--- a/content/tutorial_particle_physics/4c_information_geometry.ipynb
+++ b/content/tutorial_particle_physics/4c_information_geometry.ipynb
@@ -26,7 +26,7 @@
    "source": [
     "import sys\n",
     "import os\n",
-    "madminer_src_path = \"/home/software/MG5_aMC_v2_6_7/\"\n",
+    "madminer_src_path = \"/madminer/software/MG5_aMC_v2_6_7/\"\n",
     "sys.path.append(madminer_src_path)\n",
     "\n",
     "from __future__ import absolute_import, division, print_function, unicode_literals\n",

--- a/content/tutorial_particle_physics/A1_systematic_uncertainties.ipynb
+++ b/content/tutorial_particle_physics/A1_systematic_uncertainties.ipynb
@@ -68,7 +68,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mg_dir = \"/madminer/software/MG5_aMC_v2_6_2/\""
+    "mg_dir = \"/madminer/software/MG5_amC_v2_6_7/\""
    ]
   },
   {

--- a/content/tutorial_particle_physics/A1_systematic_uncertainties.ipynb
+++ b/content/tutorial_particle_physics/A1_systematic_uncertainties.ipynb
@@ -68,7 +68,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mg_dir = \"/home/software/MG5_aMC_v2_6_2/\""
+    "mg_dir = \"/madminer/software/MG5_aMC_v2_6_2/\""
    ]
   },
   {


### PR DESCRIPTION
This PR updates the reference to the Docker image that can be used to complete this tutorial.

The name change comes from [this refactor](https://github.com/scailfin/madminer-workflow/issues/26), and the Docker image with the updated name [is already published](https://hub.docker.com/r/madminertool/madminer-jupyter-env).