### PR TITLE
Migrate tutorial notebooks to Python3

### DIFF
--- a/content/animate.ipynb
+++ b/content/animate.ipynb
@@ -364,21 +364,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.15"
+   "pygments_lexer": "ipython3",
+   "version": "3.8.2"
   }
  },
  "nbformat": 4,

--- a/content/morphing_basis/interactive_basis_chooser.ipynb
+++ b/content/morphing_basis/interactive_basis_chooser.ipynb
@@ -237,21 +237,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.15"
+   "pygments_lexer": "ipython3",
+   "version": "3.8.2"
   }
  },
  "nbformat": 4,

--- a/content/tutorial_particle_physics/2a_parton_level_analysis.ipynb
+++ b/content/tutorial_particle_physics/2a_parton_level_analysis.ipynb
@@ -1005,21 +1005,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.12"
+   "pygments_lexer": "ipython3",
+   "version": "3.8.2"
   }
  },
  "nbformat": 4,

--- a/content/tutorial_particle_physics/2b_delphes_level_analysis.ipynb
+++ b/content/tutorial_particle_physics/2b_delphes_level_analysis.ipynb
@@ -694,21 +694,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.12"
+   "pygments_lexer": "ipython3",
+   "version": "3.8.2"
   }
  },
  "nbformat": 4,

--- a/content/tutorial_particle_physics/3a_likelihood_ratio.ipynb
+++ b/content/tutorial_particle_physics/3a_likelihood_ratio.ipynb
@@ -769,21 +769,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.12"
+   "pygments_lexer": "ipython3",
+   "version": "3.8.2"
   }
  },
  "nbformat": 4,

--- a/content/tutorial_particle_physics/3b_score.ipynb
+++ b/content/tutorial_particle_physics/3b_score.ipynb
@@ -401,21 +401,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.12"
+   "pygments_lexer": "ipython3",
+   "version": "3.8.2"
   }
  },
  "nbformat": 4,

--- a/content/tutorial_particle_physics/3c_likelihood.ipynb
+++ b/content/tutorial_particle_physics/3c_likelihood.ipynb
@@ -479,21 +479,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.12"
+   "pygments_lexer": "ipython3",
+   "version": "3.8.2"
   }
  },
  "nbformat": 4,

--- a/content/tutorial_particle_physics/4a_limits.ipynb
+++ b/content/tutorial_particle_physics/4a_limits.ipynb
@@ -713,21 +713,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.12"
+   "pygments_lexer": "ipython3",
+   "version": "3.8.2"
   }
  },
  "nbformat": 4,

--- a/content/tutorial_particle_physics/4b_fisher_information.ipynb
+++ b/content/tutorial_particle_physics/4b_fisher_information.ipynb
@@ -371,21 +371,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.12"
+   "pygments_lexer": "ipython3",
+   "version": "3.8.2"
   }
  },
  "nbformat": 4,

--- a/content/tutorial_particle_physics/A1_systematic_uncertainties.ipynb
+++ b/content/tutorial_particle_physics/A1_systematic_uncertainties.ipynb
@@ -670,21 +670,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.12"
+   "pygments_lexer": "ipython3",
+   "version": "3.8.2"
   }
  },
  "nbformat": 4,

--- a/content/tutorial_particle_physics/A2_ensemble_methods.ipynb
+++ b/content/tutorial_particle_physics/A2_ensemble_methods.ipynb
@@ -134,21 +134,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.15"
+   "pygments_lexer": "ipython3",
+   "version": "3.8.2"
   }
  },
  "nbformat": 4,

--- a/content/tutorial_particle_physics/A3_reweighting_existing_samples.ipynb
+++ b/content/tutorial_particle_physics/A3_reweighting_existing_samples.ipynb
@@ -200,9 +200,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python (higgs_inference)",
+   "display_name": "Python 3 (Higgs inference)",
    "language": "python",
-   "name": "higgs_inference"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -214,7 +214,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.8.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR migrates the kernel specification of the notebooks to Python3.

This issue came up during the [_Reinterpreting the results of new physics at the LHC tutorial_](https://indico.cern.ch/event/982553/) on 18/02/2021, as the notebooks were annoyingly asking the users which kernel to execute on.

---

_NOTE: The kernel version has been migrated to Python `3.8.2` as that is the Python3 version that Ubuntu 20.04 ships with, and all the down-stream Docker images have as the default (including the [madminer-jupyter-env](https://github.com/scailfin/madminer-jupyter-env) image used in the tutorial)._