### PR TITLE
Tutorial web GHA workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: Continuous Integration
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - "book"
+  pull_request:
+    branches:
+      - master
+    paths:
+      - "book"
+
+jobs:
+
+  build:
+    needs: []
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Set up GitHub Actions"
+        uses: actions/checkout@v2
+      - name: "Set up Python 3.7"
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+      - name: "Install Python dependencies"
+        run: |
+          pip install --no-cache-dir --upgrade pip setuptools wheel
+          pip install --no-cache-dir --requirement requirements.txt
+          pip list
+      - name: "Build web page"
+        run: |
+          make build
+      - name: "Clean web page"
+        run: |
+          make clean

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -1,0 +1,34 @@
+name: Web deployment
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - "book"
+
+jobs:
+
+  push:
+    needs: []
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Set up GitHub Actions"
+        uses: actions/checkout@v2
+      - name: "Set up Python 3.7"
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+      - name: "Install Python dependencies"
+        run: |
+          pip install --no-cache-dir --upgrade pip setuptools wheel
+          pip install --no-cache-dir --requirement requirements.txt
+          pip list
+      - name: "Build web page"
+        run: |
+          make build
+      - name: "Push built web to GitHub Pages"
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: _build/html

--- a/Makefile
+++ b/Makefile
@@ -12,3 +12,9 @@ build:
 clean:
 	@echo "Removing Jupyter book outputs..."
 	@jupyter-book clean --all $(BOOK_OUTPUT_FOLDER)
+
+
+.PHONY: push
+push: build
+	@echo "Updating published Jupyter book..."
+	@ghp-import --no-jekyll --push --force "_build/html"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
+ghp-import==1.1.0
 jupyter-book==0.10.2


### PR DESCRIPTION
This PR completes the Jupyter-Books refactor done in PR https://github.com/cranmer/madminer-tutorial/pull/10 by setting up an automatized way of testing and publishing tutorial source-code changes into the public website (https://cranmer.github.io/madminer-tutorial).

### Proposal

🤖 The GitHub Action named [peaceiris/actions-gh-pages](https://github.com/peaceiris/actions-gh-pages) will **automatically** populate a built version of the source-code to the `gh-pages` branch of this repository.

🔨  Alternatively, there is a `push` [Makefile](https://github.com/Sinclert/madminer-tutorial/blob/3461e7e8ceb79ab532aab78f11ba2bfefaf51b17/Makefile) rule to **manually** populate a built version of the source-code to the `gh-pages` branch, by using the `ghp-import` Python package. This has been kept as a _Plan B_, just in case the GHA automatization does not work.

### Remaining changes

The last piece of the puzzle is to configure, within the [Repository Settings](https://github.com/cranmer/madminer-tutorial/settings), the _GitHub Pages look-up_ to point to the `gh-pages` branch, instead of the `master` branch (as it currently does).
